### PR TITLE
fix(users)!: fix internal schema for user profiles/numberhumans

### DIFF
--- a/packages/server/src/users/numberhuman.ts
+++ b/packages/server/src/users/numberhuman.ts
@@ -61,8 +61,7 @@ export class NumberhumanData extends BaseEntity {
    * The user that caught this.
    */
   @ManyToOne(() => UserProfile, (user: UserProfile) => user.numberhumans)
-  // @ts-expect-error: cannot initialize as it will break relations
-  caughtBy: UserProfile;
+  caughtBy: UserProfile | undefined;
 
   /**
    * The total HP of the numberhuman (total HP * bonus HP)

--- a/packages/server/src/users/user-profile.ts
+++ b/packages/server/src/users/user-profile.ts
@@ -64,6 +64,5 @@ export class UserProfile extends BaseEntity {
    * Array of numberhumans the player has caught.
    */
   @OneToMany(() => NumberhumanData, (numberhuman: NumberhumanData) => numberhuman.caughtBy)
-  // @ts-expect-error: trying to add an initializer will make relations not work properly
-  numberhumans: NumberhumanData[];
+  numberhumans: NumberhumanData[] | undefined;
 }


### PR DESCRIPTION
turns out i needed a many-to-one relationship, not a many-to-many relationship
and that's why everyone keeps losing their numberhuman everytime they try to catch one